### PR TITLE
Provide an API to avoid crashing behavior on a cassette recording

### DIFF
--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -215,7 +215,6 @@ open class Session: URLSession {
         defer {
             Session.didRecordCassetteCallback()
         }
-        
         // Create directory
         let outputDirectory = (self.outputDirectory as NSString).expandingTildeInPath
         let fileManager = FileManager.default

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -4,7 +4,7 @@ open class Session: URLSession {
     // MARK: - Properties
     
     /// Replace this closure to handle recording end other than crashing.
-    public static var indicateRecordingCallback: () -> () = { abort() }
+    public static var didRecordCassetteCallback: () -> () = { abort() }
     
     public static var defaultTestBundle: Bundle? {
         return Bundle.allBundles.first { $0.bundlePath.hasSuffix(".xctest") }
@@ -213,7 +213,7 @@ open class Session: URLSession {
 
     private func persist(_ interactions: [Interaction]) {
         defer {
-            Session.indicateRecordingCallback()
+            Session.didRecordCassetteCallback()
         }
         
         // Create directory

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 open class Session: URLSession {
+
     // MARK: - Properties
     
     /// Replace this closure to handle recording end other than crashing.

--- a/Sources/DVR/Session.swift
+++ b/Sources/DVR/Session.swift
@@ -215,6 +215,7 @@ open class Session: URLSession {
         defer {
             Session.didRecordCassetteCallback()
         }
+
         // Create directory
         let outputDirectory = (self.outputDirectory as NSString).expandingTildeInPath
         let fileManager = FileManager.default

--- a/Sources/DVR/SessionDataTask.swift
+++ b/Sources/DVR/SessionDataTask.swift
@@ -5,7 +5,6 @@ final class SessionDataTask: URLSessionDataTask {
     enum TaskError: Error {
         case requestNotFound
         case cannotRecordNoResponse
-        case recordedCassette
         case cannotRecordSettingIsDisabled
     }
 
@@ -98,7 +97,7 @@ final class SessionDataTask: URLSessionDataTask {
 
             // Still call the completion block so the user can chain requests while recording.
             this.queue.async {
-                this.completion?(nil, nil, TaskError.recordedCassette as NSError)
+                this.completion?(data, response, nil)
             }
 
             // Create interaction

--- a/Tests/DVRTests/SessionTests.swift
+++ b/Tests/DVRTests/SessionTests.swift
@@ -389,7 +389,7 @@ class SessionTests: XCTestCase {
         let expectation = self.expectation(description: "Proper failure")
         let expectationRecording = self.expectation(description: "Proper failure")
         
-        Session.indicateRecordingCallback = {
+        Session.didRecordCassetteCallback = {
             expectationRecording.fulfill()
         }
         


### PR DESCRIPTION
### What

This PR introduces a new API `Session.didRecordCassetteCallback` to override `abort()` call when a new request is recorded in a cassette.

Additionally:
- replaced some of the `fatalError`-s with a callbacks and error returns to continue testing and avoid crashes
- improved tests to make them more stable and less dependent on specific values (less potential crashes)

### Why

This allows faster development cycle for re-recording (and unlocks automation). Without it every cassette stops recording and it takes more time re-record changes in several cassettes.